### PR TITLE
Add NFe status query pages

### DIFF
--- a/Testes/Pages/NfeStatus/Index.cshtml
+++ b/Testes/Pages/NfeStatus/Index.cshtml
@@ -1,0 +1,22 @@
+@page
+@model Testes.Pages.NfeStatus.IndexModel
+@{
+    ViewData["Title"] = "Consultar NFe";
+}
+
+<h1>Consultar NFe</h1>
+
+<form method="post" asp-page="Result">
+    <div class="form-group">
+        <label asp-for="Uf"></label>
+        <input asp-for="Uf" class="form-control" />
+    </div>
+    <div class="form-group">
+        <label asp-for="Ambiente"></label>
+        <select asp-for="Ambiente" class="form-control">
+            <option value="1">Produção</option>
+            <option value="2">Homologação</option>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Consultar</button>
+</form>

--- a/Testes/Pages/NfeStatus/Index.cshtml.cs
+++ b/Testes/Pages/NfeStatus/Index.cshtml.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Testes.Pages.NfeStatus
+{
+    public class IndexModel : PageModel
+    {
+        public string Uf { get; set; } = string.Empty;
+        public int Ambiente { get; set; } = 1;
+
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Testes/Pages/NfeStatus/Result.cshtml
+++ b/Testes/Pages/NfeStatus/Result.cshtml
@@ -1,0 +1,15 @@
+@page
+@model Testes.Pages.NfeStatus.ResultModel
+@{
+    ViewData["Title"] = "Resultado";
+}
+
+<h1>Resultado</h1>
+
+<div>
+    <p>UF: @Model.Uf</p>
+    <p>Ambiente: @Model.Ambiente</p>
+    <p>Status HTTP: @Model.StatusCode</p>
+    <p>Disponível: @(Model.IsAvailable ? "Sim" : "Não")</p>
+    <a asp-page="Index">Voltar</a>
+</div>

--- a/Testes/Pages/NfeStatus/Result.cshtml.cs
+++ b/Testes/Pages/NfeStatus/Result.cshtml.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Testes.Services;
+
+namespace Testes.Pages.NfeStatus
+{
+    public class ResultModel : PageModel
+    {
+        private readonly NfeStatusService _service;
+
+        public ResultModel(NfeStatusService service)
+        {
+            _service = service;
+        }
+
+        [BindProperty]
+        public string Uf { get; set; } = string.Empty;
+
+        [BindProperty]
+        public int Ambiente { get; set; }
+
+        public HttpStatusCode StatusCode { get; private set; }
+        public bool IsAvailable { get; private set; }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            StatusCode = await _service.GetStatusCodeAsync(Uf, Ambiente.ToString());
+            IsAvailable = StatusCode == HttpStatusCode.OK;
+            return Page();
+        }
+    }
+}

--- a/Testes/Program.cs
+++ b/Testes/Program.cs
@@ -1,3 +1,5 @@
+using Testes.Services;
+
 namespace Testes
 {
     public class Program
@@ -8,6 +10,7 @@ namespace Testes
 
             // Add services to the container.
             builder.Services.AddRazorPages();
+            builder.Services.AddHttpClient<NfeStatusService>();
 
             var app = builder.Build();
 

--- a/Testes/Services/NfeStatusService.cs
+++ b/Testes/Services/NfeStatusService.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Testes.Services
+{
+    /// <summary>
+    /// Service responsible for checking the availability of the NFe status service.
+    /// </summary>
+    public class NfeStatusService
+    {
+        private const string ServiceUrl = "https://nfe.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx";
+        private readonly HttpClient _httpClient;
+
+        public NfeStatusService(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        /// <summary>
+        /// Calls the NFe status service with the specified UF and environment and returns the HTTP status code.
+        /// </summary>
+        public async Task<HttpStatusCode> GetStatusCodeAsync(string uf, string ambiente)
+        {
+            var url = $"{ServiceUrl}?UF={uf}&tpAmb={ambiente}";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var response = await _httpClient.SendAsync(request);
+            return response.StatusCode;
+        }
+
+        /// <summary>
+        /// Checks if the service is available (HTTP 200 OK) for the provided UF and environment.
+        /// </summary>
+        public async Task<bool> IsServiceAvailableAsync(string uf, string ambiente)
+        {
+            try
+            {
+                var status = await GetStatusCodeAsync(uf, ambiente);
+                return status == HttpStatusCode.OK;
+            }
+            catch (HttpRequestException)
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add form page to capture UF and environment for NFe status queries
- show result on dedicated page using NfeStatusService
- update NfeStatusService to accept UF and environment parameters

## Testing
- `dotnet build` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68be516cda248327971cb3074b35cd2a